### PR TITLE
fix: pin GitHub Actions to commit SHAs (INT-326)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Trunk Check
-        uses: trunk-io/trunk-action@v1
+        uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -7,7 +7,7 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.7.3
+      ref: v1.7.6
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
@@ -20,16 +20,17 @@ lint:
     # Incompatible with some Terraform features: https://github.com/tenable/terrascan/issues/1331
     - terrascan
   enabled:
+    - renovate@43.104.1
     - tofu@1.10.6
     - actionlint@1.7.8
-    - checkov@3.2.489
+    - checkov@3.2.513
     - git-diff-check
-    - markdownlint@0.45.0
-    - prettier@3.6.2
+    - markdownlint@0.48.0
+    - prettier@3.8.1
     - tflint@0.59.1
-    - trivy@0.67.2
-    - trufflehog@3.90.12
-    - yamllint@1.37.1
+    - trivy@0.69.2
+    - trufflehog@3.90.13
+    - yamllint@1.38.0
   ignore:
     - linters: [tofu]
       paths:

--- a/root-modules/template-root-module/README.md
+++ b/root-modules/template-root-module/README.md
@@ -38,7 +38,7 @@ This approach ensures that:
 
 | Name      | Version  |
 | --------- | -------- |
-| terraform | 1.10.3   |
+| terraform | 1.13.3   |
 | random    | ~> 3.7.2 |
 
 ## Providers


### PR DESCRIPTION
## Info

- Pins all `uses:` references in GitHub Actions workflows to full commit SHAs.

## References

- https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions