### PR TITLE
chore: add minimumReleaseAge and GHA manager (INT-356)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,7 +14,9 @@
     'auto-upgrade',
   ],
   dependencyDashboardAutoclose: true,
+  minimumReleaseAge: '3 days',
   enabledManagers: [
+    'github-actions',
     'terraform',
   ],
   terraform: {


### PR DESCRIPTION
## what

Add two Renovate configuration improvements to `.github/renovate.json5`:
- Set `minimumReleaseAge`: `3 days` globally so Renovate waits 3 days after any release before opening an upgrade PR. This applies to all managed dependency types.
- Add `github-actions` to enabledManagers. We also want to make sure we enable `pinDigests: true` here, but that is already handled since we use [config:best-practices](https://docs.renovatebot.com/presets-config/#configbest-practices), which includes [this](https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigests). Renovate will now track workflow dependencies and pin them to immutable SHA digests instead of mutable version tags. We are already doing this in practice, but this enforces it in a maintainable way. 

## why

The `minimumReleaseAge` window gives the community time to discover and report bugs or vulnerabilities in newly published releases before we adopt them. Without it, Renovate could open a PR for a release within minutes of it being published — before any post-release issues are known.

Pinning GitHub Actions to SHA digests removes a supply chain attack vector: a compromised or malicious actor could rewrite a version tag (e.g. v4) to point at different code without any visible change to our workflow files. A pinned digest is immutable and tied to a specific commit. Renovate's digest update PRs will keep those pins current over time.

## references

- [INT-356](https://www.notion.so/masterpoint/Update-Renovate-configs-with-minimumReleaseAge-and-pinDigests-168a707e8c564134b3586fd6a2553233)
